### PR TITLE
Adds simple migration version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Trying to write code mod for converting `@jpmorganchase/uitk-` to `@salt-ds/*`.
 1. Clone this codemod repo, then `yarn install` to get all the dependencies (e.g. `ts-morph`)
 2. In your project repo, update `package.json` to use `@salt-ds/*` and install dependencies (Refer to [these lines](https://github.com/origami-z/salt-codemod/blob/f974c4d16a1000248ea16b86c8970924aea33103/index.js#L79-L99) for package name mapping). The script doesn't support updating `package.json` yet, and it reads `@salt-ds/theme/index.css` for CSS variable verification, so you need to manually install new dependencies.
 3. Run `node /path/to/this/repo/index.js`
+
+Use `--help` to see all available flags. e.g. if you want to migrate from v1.0.0 to v1.1.0, then do `--from 1.0.0 --to 1.1.0`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.12",
+    "semver": "^7.3.8",
     "ts-morph": "^17.0.1",
     "yargs": "^17.6.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,13 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -216,6 +223,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -260,6 +274,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
`@salt-ds/core@1.1.0` is [released](https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.1.0), adds some support for defining migration range. Added `Card` and `Panel` import change as example.