### PR TITLE
Changed logic so when `tsSourceGlob` is provided, `tsconifg` option is ignored

### DIFF
--- a/.changeset/slow-moons-happen.md
+++ b/.changeset/slow-moons-happen.md
@@ -1,0 +1,5 @@
+---
+"salt-codemod": patch
+---
+
+Changed logic so when `tsSourceGlob` is provided, `tsconifg` option is ignored

--- a/.changeset/tasty-peas-vanish.md
+++ b/.changeset/tasty-peas-vanish.md
@@ -1,0 +1,5 @@
+---
+"salt-codemod": patch
+---
+
+Use terminal width for yargs

--- a/index.js
+++ b/index.js
@@ -47,7 +47,14 @@ import {
   LATEST_SUPPORTED_VERSION,
   parsedArgs,
 } from "./utils/args.js";
-import { verboseOnlyDimLog } from "./utils/log.js";
+import {
+  verboseOnlyDimLog,
+  verboseOnlyTableLog,
+  verboseOnlyLog,
+} from "./utils/log.js";
+
+verboseOnlyLog("Args used:");
+verboseOnlyTableLog(parsedArgs);
 
 const {
   tsconfig,
@@ -148,17 +155,20 @@ if (mode === undefined || mode === "ts") {
   // Check, in case of monorepo which doesn't have tsconfig at the root
   const tsConfigExisted = existsSync(tsconfig);
 
+  // Ignore tsconfig if `tsSourceGlob` option is provided
+  const initialiseFromTsConfig = !tsSourceGlob && tsConfigExisted;
+
   const project = new Project({
     // Optionally specify compiler options, tsconfig.json, in-memory file system, and more here.
     // If you initialize with a tsconfig.json, then it will automatically populate the project
     // with the associated source files.
     // Read more: https://ts-morph.com/setup/
-    tsConfigFilePath: tsConfigExisted ? tsconfig : undefined,
+    tsConfigFilePath: initialiseFromTsConfig ? tsconfig : undefined,
   });
 
   // console.log(project);
 
-  if (tsConfigExisted) {
+  if (initialiseFromTsConfig) {
     console.log(chalk.dim("Initialising TypeScript project from", tsconfig));
     // project.addSourceFilesFromTsConfig();
   } else {
@@ -169,7 +179,7 @@ if (mode === undefined || mode === "ts") {
         ". (Use --tsSourceGlob flag to customize)"
       )
     );
-    // Very bad way of handling monorepo, adding all ts files from `tsSourceGlob` args, by default is all ts* in packages folder
+    // One example way of handling monorepo, adding all ts files from `tsSourceGlob` args, by default is all ts* in packages folder
     project.addSourceFilesAtPaths(tsSourceGlob);
   }
 

--- a/utils/args.js
+++ b/utils/args.js
@@ -17,8 +17,8 @@ export const parsedArgs = await yargs
   })
   .option("tsSourceGlob", {
     type: "string",
-    description: `React source glob to be used by ts-morph, which is useful for monorepo where tsconfig is not available at the root.
-When provided, \`tsconfig\` is ignored.  e.g., "packages/**/*.ts*"`,
+    description:
+      'React source glob to be used by ts-morph, which is useful for monorepo where tsconfig is not available at the root. When provided, `tsconfig` is ignored.  e.g., "packages/**/*.ts*"',
   })
   .option("themeCss", {
     type: "string",
@@ -73,6 +73,7 @@ When provided, \`tsconfig\` is ignored.  e.g., "packages/**/*.ts*"`,
     type: "boolean",
     description: `Skip check and upgrade all @salt-ds packages. Default to true in dryRun mode.`,
   })
+  .wrap(yargs.terminalWidth())
   .help()
   .example(`$0 --from 1.30.0 --to 1.36.0 --tsSourceGlob "packages/**/*.ts*"`)
   .alias("help", "h").argv;

--- a/utils/args.js
+++ b/utils/args.js
@@ -13,12 +13,12 @@ export const parsedArgs = await yargs
   .option("tsconfig", {
     default: "tsconfig.json",
     description:
-      "React code is modified using ts-morph, which needs a path to your tsconfig.json file.",
+      "React code is modified using ts-morph, which needs a path to your tsconfig.json file. Ignored when `tsSourceGlob` is provided.",
   })
   .option("tsSourceGlob", {
-    default: "packages/**/*.ts*",
-    description:
-      "React source glob to be used by ts-morph, which is useful for monorepo where tsconfig is not available at the root.",
+    type: "string",
+    description: `React source glob to be used by ts-morph, which is useful for monorepo where tsconfig is not available at the root.
+When provided, \`tsconfig\` is ignored.  e.g., "packages/**/*.ts*"`,
   })
   .option("themeCss", {
     type: "string",
@@ -34,7 +34,6 @@ export const parsedArgs = await yargs
   .option("verbose", {
     type: "boolean",
     default: false,
-    alias: "v",
     description: "verbose logging",
   })
   .option("organizeImports", {

--- a/utils/log.js
+++ b/utils/log.js
@@ -14,3 +14,7 @@ export function verboseOnlyLog(...data) {
 export function verboseOnlyBoldLog(...data) {
   (verbose || dryRun) && console.log(chalk.bold(...data));
 }
+
+export function verboseOnlyTableLog(...data) {
+  (verbose || dryRun) && console.table(...data);
+}


### PR DESCRIPTION
+ [Use terminal width for yargs](https://github.com/origami-z/salt-codemod/pull/23/commits/08463bdfa6820c19ebc57266a09a72140fc312a5)