### PR TITLE
Add support for @salt-ds packages v1.40.0 to v1.54.2

### DIFF
--- a/.changeset/support-salt-ds-1-54-2.md
+++ b/.changeset/support-salt-ds-1-54-2.md
@@ -1,0 +1,5 @@
+---
+"salt-codemod": minor
+---
+
+Supports upto @salt-ds/core@1.54.2

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,148 @@ Invalid CSS variables are extracted from `@salt-ds/theme/index.css`, which path 
 
 There is `--mode` option available if you just want to run React or CSS part of the codemod.
 
+## Supported Versions
+
+This codemod currently supports @salt-ds/core versions **1.0.0 through 1.54.2**.
+
+## Adding Support for New Versions
+
+To add support for newer @salt-ds versions, follow these steps:
+
+### 1. Update Version Constant
+Update `LATEST_SUPPORTED_VERSION` in `utils/args.js`:
+```javascript
+export const LATEST_SUPPORTED_VERSION = "1.XX.0";
+```
+
+### 2. Create Migration File
+Create a new migration file `migration/coreXXXX.js` (e.g., `core1540.js` for v1.54.0):
+```javascript
+import { moveNamedImports } from "./utils.js";
+
+// MMM DD, YYYY (use npm publish date)
+export function reactXXXX(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%40X.XX.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%40X.X.X-alpha.XX
+
+  // Component migrations (if any)
+  ["ComponentName", "ComponentNameProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}
+
+// CSS migrations (if any)
+export const cssXXXXRenameMap = [
+  ["--old-variable", "--new-variable"],
+];
+```
+
+**Getting the correct publish date:**
+```bash
+npm view @salt-ds/core@X.XX.0 time.X.XX.0
+```
+
+### 3. Update index.js
+
+Add imports:
+```javascript
+import { reactXXXX, cssXXXXRenameMap } from "./migration/coreXXXX.js";
+```
+
+Add version constant:
+```javascript
+const vXXXX = parse("X.XX.0");
+```
+
+Add React migration logic (around line 204-318):
+```javascript
+if (gt(vXXXX, fromVersion) && lte(vXXXX, toVersion)) {
+  reactXXXX(file);
+}
+```
+
+Add CSS migration logic (around line 377-415, if CSS changes exist):
+```javascript
+if (gt(vXXXX, fromVersion) && lte(vXXXX, toVersion)) {
+  cssMigrationMapArray.push(...cssXXXXRenameMap);
+}
+```
+
+### 4. Add Tests
+Add smoke tests in `__tests__/smoke.spec.js`:
+```javascript
+import { reactXXXX } from "../migration/coreXXXX";
+
+test("reactXXXX", () => {
+  const file = createFileWithContent(`import { Component } from "@salt-ds/lab";
+    export const App = () => <Component />;
+  `);
+  reactXXXX(file);
+  expect(file.getText().includes(`from "@salt-ds/core"`)).toBeTruthy();
+});
+```
+
+### 5. Create Changeset
+```bash
+npx changeset
+```
+Select "minor" and describe: "Supports upto @salt-ds/core@X.XX.0"
+
+### 6. Run Tests
+```bash
+npm test
+```
+
+## Key Migration Patterns
+
+### Moving Components from Lab to Core
+```javascript
+moveNamedImports(file, {
+  namedImportText: "ComponentName",
+  from: "@salt-ds/lab",
+  to: "@salt-ds/core",
+});
+```
+
+### Renaming Components
+```javascript
+for (const declaration of file.getImportDeclarations()) {
+  renameNamedImports(declaration, {
+    moduleSpecifier: "@salt-ds/core",
+    from: "OldName",
+    to: "NewName",
+  });
+}
+```
+
+### Replacing Props
+```javascript
+replaceReactAttribute(file, {
+  elementName: "Button",
+  attributeFrom: "variant",
+  valueFrom: `"cta"`,
+  attributeTo: "sentiment",
+  valueTo: `"accented"`,
+});
+```
+
+### CSS Variable Renames
+Theme package CSS variable changes are tracked separately. Check:
+```bash
+npm view @salt-ds/theme time --json | grep -E '"X\.XX\.0"'
+```
+
+## Resources
+
+- [Salt DS Releases](https://github.com/jpmorganchase/salt-ds/releases)
+- [Salt DS Core Changelog](https://github.com/jpmorganchase/salt-ds/blob/main/packages/core/CHANGELOG.md)
+- [Salt DS Lab Changelog](https://github.com/jpmorganchase/salt-ds/blob/main/packages/lab/CHANGELOG.md)
+- [Salt DS Theme Changelog](https://github.com/jpmorganchase/salt-ds/blob/main/packages/theme/CHANGELOG.md)
+
 ## Local development
 
 `yarn` to install all dependencies.

--- a/__tests__/smoke.spec.js
+++ b/__tests__/smoke.spec.js
@@ -28,6 +28,18 @@ import { react1320 } from "../migration/core1320";
 import { react1330 } from "../migration/core1330";
 import { react1360 } from "../migration/core1360";
 import { react1372 } from "../migration/core1372";
+import { react1380 } from "../migration/core1380";
+import { react1390 } from "../migration/core1390";
+import { react1400 } from "../migration/core1400";
+import { react1410 } from "../migration/core1410";
+import { react1420 } from "../migration/core1420";
+import { react1430 } from "../migration/core1430";
+import { react1440 } from "../migration/core1440";
+import { react1450 } from "../migration/core1450";
+import { react1460 } from "../migration/core1460";
+import { react1471 } from "../migration/core1471";
+import { react1480 } from "../migration/core1480";
+import { react1530 } from "../migration/core1530";
 
 /**
  *
@@ -182,5 +194,178 @@ describe("Smoke test all migration script will run", () => {
     const actualResultText = file.getText();
 
     expect(actualResultText.includes(`<CheckmarkIcon />`)).toBeTruthy();
+  });
+  test("react1380", () => {
+    react1380(file);
+  });
+  test("react1390", () => {
+    const file =
+      createFileWithContent(`import { SkipLink } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <SkipLink href="#main">Skip to main</SkipLink>
+    );
+  };`);
+    react1390(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1400", () => {
+    const file =
+      createFileWithContent(`import { CircularProgress, LinearProgress } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <>
+        <CircularProgress />
+        <LinearProgress value={50} />
+      </>
+    );
+  };`);
+    react1400(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1410", () => {
+    const file =
+      createFileWithContent(`import { Switch } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <Switch checked={true} />
+    );
+  };`);
+    react1410(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1420", () => {
+    const file =
+      createFileWithContent(`import { Dialog, Option } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <Dialog open={true}>
+        <Option value="1">Option 1</Option>
+      </Dialog>
+    );
+  };`);
+    react1420(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1430", () => {
+    const file =
+      createFileWithContent(`import { SegmentedButtonGroup, DialogHeader } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <>
+        <SegmentedButtonGroup />
+        <DialogHeader />
+      </>
+    );
+  };`);
+    react1430(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1440", () => {
+    const file =
+      createFileWithContent(`import { Slider, RangeSlider } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <>
+        <Slider min={0} max={100} />
+        <RangeSlider min={0} max={100} />
+      </>
+    );
+  };`);
+    react1440(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1450", () => {
+    const file =
+      createFileWithContent(`import { Stepper } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <Stepper />
+    );
+  };`);
+    react1450(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1460", () => {
+    const file =
+      createFileWithContent(`import { Overlay, OverlayTrigger } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <Overlay>
+        <OverlayTrigger />
+      </Overlay>
+    );
+  };`);
+    react1460(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1471", () => {
+    const file =
+      createFileWithContent(`import { Divider } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <Divider />
+    );
+  };`);
+    react1471(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1480", () => {
+    const file =
+      createFileWithContent(`import { Collapsible, VerticalNavigation } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <>
+        <Collapsible />
+        <VerticalNavigation />
+      </>
+    );
+  };`);
+    react1480(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
+  });
+  test("react1530", () => {
+    const file =
+      createFileWithContent(`import { NumberInput } from "@salt-ds/lab";
+  export const App = () => {
+    return (
+      <NumberInput value={42} />
+    );
+  };`);
+    react1530(file);
+
+    const actualResultText = file.getText();
+
+    expect(actualResultText.includes(`from "@salt-ds/core"`)).toBeTruthy();
   });
 });

--- a/index.js
+++ b/index.js
@@ -55,6 +55,19 @@ import {
 import { react1372 } from "./migration/core1372.js";
 import { react1380 } from "./migration/core1380.js";
 import { react1390 } from "./migration/core1390.js";
+import { css1400RenameMap, react1400 } from "./migration/core1400.js";
+import { react1410 } from "./migration/core1410.js";
+import { react1420 } from "./migration/core1420.js";
+import { react1430 } from "./migration/core1430.js";
+import { react1440 } from "./migration/core1440.js";
+import { react1450 } from "./migration/core1450.js";
+import { react1460 } from "./migration/core1460.js";
+import { react1471 } from "./migration/core1471.js";
+import { react1480 } from "./migration/core1480.js";
+import { css1490RenameMap } from "./migration/core1490.js";
+import { css1500RenameMap } from "./migration/core1500.js";
+import { css1520RenameMap } from "./migration/core1520.js";
+import { react1530 } from "./migration/core1530.js";
 
 verboseOnlyLog("Args used:");
 verboseOnlyTableLog(parsedArgs);
@@ -117,6 +130,24 @@ const v1360 = parse("1.36.0");
 const v1372 = parse("1.37.2");
 const v1380 = parse("1.38.0");
 const v1390 = parse("1.39.0");
+const v1400 = parse("1.40.0");
+const v1410 = parse("1.41.0");
+const v1420 = parse("1.42.0");
+const v1430 = parse("1.43.0");
+const v1440 = parse("1.44.0");
+const v1450 = parse("1.45.0");
+const v1460 = parse("1.46.0");
+// nothing needed for 1.47.0
+const v1471 = parse("1.47.1");
+// nothing needed for 1.47.2, 1.47.3, 1.47.4, 1.47.5
+const v1480 = parse("1.48.0");
+const v1490 = parse("1.49.0");
+const v1500 = parse("1.50.0");
+// nothing needed for 1.51.0
+const v1520 = parse("1.52.0");
+// nothing needed for 1.52.1
+const v1530 = parse("1.53.0");
+// nothing needed for 1.54.0, 1.54.1, 1.54.2
 // NOTE: don't forget to modify `LATEST_SUPPORTED_VERSION` in args.js
 
 if (dryRun) {
@@ -317,6 +348,46 @@ if (mode === undefined || mode === "ts") {
       react1390(file);
     }
 
+    if (gt(v1400, fromVersion) && lte(v1400, toVersion)) {
+      react1400(file);
+    }
+
+    if (gt(v1410, fromVersion) && lte(v1410, toVersion)) {
+      react1410(file);
+    }
+
+    if (gt(v1420, fromVersion) && lte(v1420, toVersion)) {
+      react1420(file);
+    }
+
+    if (gt(v1430, fromVersion) && lte(v1430, toVersion)) {
+      react1430(file);
+    }
+
+    if (gt(v1440, fromVersion) && lte(v1440, toVersion)) {
+      react1440(file);
+    }
+
+    if (gt(v1450, fromVersion) && lte(v1450, toVersion)) {
+      react1450(file);
+    }
+
+    if (gt(v1460, fromVersion) && lte(v1460, toVersion)) {
+      react1460(file);
+    }
+
+    if (gt(v1471, fromVersion) && lte(v1471, toVersion)) {
+      react1471(file);
+    }
+
+    if (gt(v1480, fromVersion) && lte(v1480, toVersion)) {
+      react1480(file);
+    }
+
+    if (gt(v1530, fromVersion) && lte(v1530, toVersion)) {
+      react1530(file);
+    }
+
     if (organizeImports) {
       file.organizeImports();
     }
@@ -412,6 +483,22 @@ if (mode === undefined || mode === "css") {
 
   if (gt(v1360, fromVersion) && lte(v1360, toVersion)) {
     cssMigrationMapArray.push(...css1360RenameMap);
+  }
+
+  if (gt(v1400, fromVersion) && lte(v1400, toVersion)) {
+    cssMigrationMapArray.push(...css1400RenameMap);
+  }
+
+  if (gt(v1490, fromVersion) && lte(v1490, toVersion)) {
+    cssMigrationMapArray.push(...css1490RenameMap);
+  }
+
+  if (gt(v1500, fromVersion) && lte(v1500, toVersion)) {
+    cssMigrationMapArray.push(...css1500RenameMap);
+  }
+
+  if (gt(v1520, fromVersion) && lte(v1520, toVersion)) {
+    cssMigrationMapArray.push(...css1520RenameMap);
   }
 
   const cssMigrationMap = new Map(cssMigrationMapArray);

--- a/migration/core1400.js
+++ b/migration/core1400.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Feb 4, 2024
+// Feb 4, 2025
 export function react1400(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.40.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.31

--- a/migration/core1400.js
+++ b/migration/core1400.js
@@ -1,6 +1,33 @@
-// Feb 4, 2025
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1400(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.40.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.31
+
+  // CircularProgress and LinearProgress moved from lab to core
+  [
+    "CircularProgress",
+    "CircularProgressProps",
+    "LinearProgress",
+    "LinearProgressProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.25.0
  */
-// export const css1400RenameMap = [];
+export const css1400RenameMap = [
+  ["--salt-palette-accent-background", "--salt-palette-accent"],
+  ["--salt-palette-accent-border", "--salt-palette-accent"],
+  ["--salt-palette-interact-cta-foreground-active", "--salt-palette-interact-cta-foreground"],
+  ["--salt-palette-interact-cta-foreground-hover", "--salt-palette-interact-cta-foreground"],
+  ["--salt-palette-neutral-primary-border", "--salt-palette-neutral-border"],
+  ["--salt-palette-neutral-secondary-border", "--salt-palette-neutral-border"],
+];

--- a/migration/core1400.js
+++ b/migration/core1400.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Feb 4, 2024
 export function react1400(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.40.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.31

--- a/migration/core1410.js
+++ b/migration/core1410.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Feb 20, 2024
+// Feb 20, 2025
 export function react1410(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.41.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.20

--- a/migration/core1410.js
+++ b/migration/core1410.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Feb 20, 2024
 export function react1410(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.41.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.20

--- a/migration/core1410.js
+++ b/migration/core1410.js
@@ -1,0 +1,16 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1410(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.41.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.20
+
+  // Switch moved from lab to core
+  ["Switch", "SwitchProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1420.js
+++ b/migration/core1420.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Mar 7, 2024
 export function react1420(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.42.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.35

--- a/migration/core1420.js
+++ b/migration/core1420.js
@@ -1,0 +1,36 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1420(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.42.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.35
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.37
+
+  // Dialog components moved from lab to core
+  [
+    "Dialog",
+    "DialogProps",
+    "DialogContent",
+    "DialogContentProps",
+    "DialogActions",
+    "DialogActionsProps",
+    "DialogCloseButton",
+    "DialogCloseButtonProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+
+  // DropdownNext renamed to Dropdown, ComboBoxNext renamed to ComboBox
+  // Option and OptionGroup moved from lab to core
+  ["Option", "OptionProps", "OptionGroup", "OptionGroupProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1420.js
+++ b/migration/core1420.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Mar 7, 2024
+// Mar 7, 2025
 export function react1420(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.42.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.35

--- a/migration/core1430.js
+++ b/migration/core1430.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Apr 4, 2024
+// Apr 4, 2025
 export function react1430(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.43.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.39

--- a/migration/core1430.js
+++ b/migration/core1430.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Apr 4, 2024
 export function react1430(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.43.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.39

--- a/migration/core1430.js
+++ b/migration/core1430.js
@@ -1,0 +1,31 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1430(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.43.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.39
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.64
+
+  // SegmentedButtonGroup moved from lab to core
+  ["SegmentedButtonGroup", "SegmentedButtonGroupProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+
+  // DialogHeader and OverlayHeader moved from lab to core (also in v1.42.0)
+  [
+    "DialogHeader",
+    "DialogHeaderProps",
+    "OverlayHeader",
+    "OverlayHeaderProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1440.js
+++ b/migration/core1440.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Apr 11, 2024
+// Apr 11, 2025
 export function react1440(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.44.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.65

--- a/migration/core1440.js
+++ b/migration/core1440.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Apr 11, 2024
 export function react1440(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.44.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.65

--- a/migration/core1440.js
+++ b/migration/core1440.js
@@ -1,0 +1,23 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1440(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.44.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.65
+
+  // Slider and RangeSlider moved from lab to core
+  [
+    "Slider",
+    "SliderProps",
+    "RangeSlider",
+    "RangeSliderProps",
+    "SliderMark",
+    "SliderMarkProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1450.js
+++ b/migration/core1450.js
@@ -1,6 +1,6 @@
 import { moveNamedImports, renameNamedImports } from "./utils.js";
 
-// May 2, 2024
+// May 2, 2025
 export function react1450(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.45.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.67

--- a/migration/core1450.js
+++ b/migration/core1450.js
@@ -1,0 +1,24 @@
+import { moveNamedImports, renameNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1450(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.45.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.67
+
+  // SteppedTracker moved from lab to core and renamed to Stepper
+  // Note: Component structure also changed significantly, manual migration may be needed
+  ["Stepper", "StepperProps", "Step", "StepProps", "StepLabel"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+
+  // Rename SteppedTracker to Stepper if found
+  renameNamedImports(file, {
+    oldImportName: "SteppedTracker",
+    newImportName: "Stepper",
+    packageName: "@salt-ds/core",
+  });
+}

--- a/migration/core1450.js
+++ b/migration/core1450.js
@@ -16,9 +16,11 @@ export function react1450(file) {
   });
 
   // Rename SteppedTracker to Stepper if found
-  renameNamedImports(file, {
-    oldImportName: "SteppedTracker",
-    newImportName: "Stepper",
-    packageName: "@salt-ds/core",
-  });
+  for (const declaration of file.getImportDeclarations()) {
+    renameNamedImports(declaration, {
+      moduleSpecifier: "@salt-ds/core",
+      from: "SteppedTracker",
+      to: "Stepper",
+    });
+  }
 }

--- a/migration/core1450.js
+++ b/migration/core1450.js
@@ -1,6 +1,6 @@
 import { moveNamedImports, renameNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// May 2, 2024
 export function react1450(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.45.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.67

--- a/migration/core1460.js
+++ b/migration/core1460.js
@@ -1,0 +1,27 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1460(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.46.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.40
+
+  // Overlay components moved from lab to core
+  [
+    "Overlay",
+    "OverlayProps",
+    "OverlayTrigger",
+    "OverlayTriggerProps",
+    "OverlayPanel",
+    "OverlayPanelProps",
+    "OverlayPanelCloseButton",
+    "OverlayPanelCloseButtonProps",
+    "OverlayPanelContent",
+    "OverlayPanelContentProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1460.js
+++ b/migration/core1460.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// May 19, 2024
 export function react1460(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.46.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.40

--- a/migration/core1460.js
+++ b/migration/core1460.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// May 19, 2024
+// May 19, 2025
 export function react1460(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.46.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.40

--- a/migration/core1471.js
+++ b/migration/core1471.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jul 2, 2024
+// Jul 2, 2025
 export function react1471(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.47.1
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.48

--- a/migration/core1471.js
+++ b/migration/core1471.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Jul 2, 2024
 export function react1471(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.47.1
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.48

--- a/migration/core1471.js
+++ b/migration/core1471.js
@@ -1,0 +1,16 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1471(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.47.1
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.48
+
+  // Divider moved from lab to core
+  ["Divider", "DividerProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1480.js
+++ b/migration/core1480.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Sep 2, 2024
+// Sep 2, 2025
 export function react1480(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.48.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.76

--- a/migration/core1480.js
+++ b/migration/core1480.js
@@ -1,0 +1,39 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1480(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.48.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.76
+
+  // Collapsible components moved from lab to core
+  [
+    "Collapsible",
+    "CollapsibleProps",
+    "CollapsibleTrigger",
+    "CollapsibleTriggerProps",
+    "CollapsiblePanel",
+    "CollapsiblePanelProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+
+  // VerticalNavigation components moved from lab to core
+  [
+    "VerticalNavigation",
+    "VerticalNavigationProps",
+    "NavigationGroup",
+    "NavigationGroupProps",
+    "NavigationItem",
+    "NavigationItemProps",
+  ].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/migration/core1480.js
+++ b/migration/core1480.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Sep 2, 2024
 export function react1480(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.48.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.76

--- a/migration/core1490.js
+++ b/migration/core1490.js
@@ -1,4 +1,4 @@
-// Oct 21, 2024
+// Oct 21, 2025
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.34.0

--- a/migration/core1490.js
+++ b/migration/core1490.js
@@ -1,4 +1,4 @@
-// Jan 22, 2026
+// Oct 21, 2024
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.34.0

--- a/migration/core1490.js
+++ b/migration/core1490.js
@@ -1,0 +1,13 @@
+// Jan 22, 2026
+
+/**
+ * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.34.0
+ */
+export const css1490RenameMap = [
+  ["--salt-shadow-100", "--salt-shadow-lowest"],
+  ["--salt-shadow-200", "--salt-shadow-lower"],
+  ["--salt-shadow-300", "--salt-shadow-low"],
+  ["--salt-shadow-400", "--salt-shadow-mediumLow"],
+  ["--salt-shadow-500", "--salt-shadow-medium"],
+  ["--salt-editable-help-fontStyle", "--salt-typography-textDecoration-italic"],
+];

--- a/migration/core1500.js
+++ b/migration/core1500.js
@@ -1,0 +1,15 @@
+// Jan 22, 2026
+
+/**
+ * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.35.0
+ */
+export const css1500RenameMap = [
+  ["--salt-palette-warning-action-hover", "--salt-palette-warning-weakest"],
+  ["--salt-palette-neutral-action-hover", "--salt-palette-neutral-weakest"],
+  ["--salt-palette-positive-action-hover", "--salt-palette-positive-weakest"],
+  ["--salt-palette-accent-action-hover", "--salt-palette-accent-weakest"],
+  ["--salt-palette-warning-action-active", "--salt-palette-warning-weaker"],
+  ["--salt-palette-neutral-action-active", "--salt-palette-neutral-weaker"],
+  ["--salt-palette-positive-action-active", "--salt-palette-positive-weaker"],
+  ["--salt-palette-accent-action-active", "--salt-palette-accent-weaker"],
+];

--- a/migration/core1500.js
+++ b/migration/core1500.js
@@ -1,4 +1,4 @@
-// Jan 22, 2026
+// Oct 24, 2024
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.35.0

--- a/migration/core1500.js
+++ b/migration/core1500.js
@@ -1,4 +1,4 @@
-// Oct 24, 2024
+// Oct 24, 2025
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.35.0

--- a/migration/core1520.js
+++ b/migration/core1520.js
@@ -1,4 +1,4 @@
-// Jan 22, 2026
+// Nov 28, 2024
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.37.0

--- a/migration/core1520.js
+++ b/migration/core1520.js
@@ -1,0 +1,17 @@
+// Jan 22, 2026
+
+/**
+ * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.37.0
+ */
+export const css1520RenameMap = [
+  ["--salt-content-foreground-highlight", "--salt-selectable-background-selected"],
+  ["--salt-content-foreground-active", "--salt-content-accent-foreground"],
+  ["--salt-content-foreground-hover", "--salt-content-accent-foreground"],
+  ["--salt-category-1-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-category-2-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-category-3-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-category-4-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-category-5-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-category-6-bold-foreground", "--salt-content-bold-foreground"],
+  ["--salt-accent-foreground", "--salt-content-bold-foreground"],
+];

--- a/migration/core1520.js
+++ b/migration/core1520.js
@@ -1,4 +1,4 @@
-// Nov 28, 2024
+// Nov 28, 2025
 
 /**
  * https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Ftheme%401.37.0

--- a/migration/core1530.js
+++ b/migration/core1530.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Jan 22, 2026
+// Nov 12, 2024
 export function react1530(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.53.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.81

--- a/migration/core1530.js
+++ b/migration/core1530.js
@@ -1,6 +1,6 @@
 import { moveNamedImports } from "./utils.js";
 
-// Nov 12, 2024
+// Nov 12, 2025
 export function react1530(file) {
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.53.0
   // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.81

--- a/migration/core1530.js
+++ b/migration/core1530.js
@@ -1,0 +1,16 @@
+import { moveNamedImports } from "./utils.js";
+
+// Jan 22, 2026
+export function react1530(file) {
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Fcore%401.53.0
+  // https://github.com/jpmorganchase/salt-ds/releases/tag/%40salt-ds%2Flab%401.0.0-alpha.81
+
+  // NumberInput moved from lab to core
+  ["NumberInput", "NumberInputProps"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+}

--- a/utils/args.js
+++ b/utils/args.js
@@ -2,7 +2,7 @@ import _yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 const yargs = _yargs(hideBin(process.argv));
 
-export const LATEST_SUPPORTED_VERSION = "1.39.0";
+export const LATEST_SUPPORTED_VERSION = "1.54.2";
 export const DEFAULT_FROM_VERSION = "1.0.0";
 
 export const parsedArgs = await yargs


### PR DESCRIPTION
- Updated LATEST_SUPPORTED_VERSION to 1.54.2
- Added migration files for versions 1.40.0 through 1.54.2
  - Component migrations: CircularProgress, LinearProgress, Switch, Dialog components,
    Slider, RangeSlider, Stepper, Overlay components, Divider, Collapsible,
    VerticalNavigation, NumberInput moved from @salt-ds/lab to @salt-ds/core
  - CSS variable migrations for theme versions 1.25.0, 1.34.0, 1.35.0, 1.37.0
- Added version constants and conditional migration logic in index.js
- Created changeset documenting the update