### PR TITLE
Add support for theme-next.css CSS variable validation

### DIFF
--- a/.changeset/support-theme-next-css.md
+++ b/.changeset/support-theme-next-css.md
@@ -1,0 +1,5 @@
+---
+"salt-codemod": minor
+---
+
+Support CSS variable validation from theme-next.css when SaltProviderNext is detected in the codebase. This prevents false errors for variables defined in theme-next.css.

--- a/__tests__/migration/utils.spec.js
+++ b/__tests__/migration/utils.spec.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import * as tsm from "ts-morph";
 import {
+  detectSaltProviderNext,
   getCssRenameCheckRegex,
   moveNamedImports,
   renameReactElementName,
@@ -288,5 +289,135 @@ describe("replaceReactAttribute", () => {
     });
     const actualResultText = file.getText();
     expect(actualResultText).toContain(`<ComponentTWO prop2="b">`);
+  });
+});
+
+describe("detectSaltProviderNext", () => {
+  test("detects SaltProviderNext from @salt-ds/core", () => {
+    const file = createFileWithContent(
+      `import { SaltProvider, SaltProviderNext } from "@salt-ds/core";
+
+  export const App = () => {
+    return (
+      <SaltProviderNext>
+        <div>Hello</div>
+      </SaltProviderNext>
+    );
+  };`
+    );
+
+    const project = file.getProject();
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(true);
+  });
+
+  test("detects SaltProviderNext from @salt-ds/lab", () => {
+    const file = createFileWithContent(
+      `import { SaltProviderNext } from "@salt-ds/lab";
+
+  export const App = () => {
+    return (
+      <SaltProviderNext>
+        <div>Hello</div>
+      </SaltProviderNext>
+    );
+  };`
+    );
+
+    const project = file.getProject();
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(true);
+  });
+
+  test("returns false when only SaltProvider is imported", () => {
+    const file = createFileWithContent(
+      `import { SaltProvider } from "@salt-ds/core";
+
+  export const App = () => {
+    return (
+      <SaltProvider>
+        <div>Hello</div>
+      </SaltProvider>
+    );
+  };`
+    );
+
+    const project = file.getProject();
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(false);
+  });
+
+  test("returns false when no salt-ds imports exist", () => {
+    const file = createFileWithContent(
+      `import React from "react";
+
+  export const App = () => {
+    return <div>Hello</div>;
+  };`
+    );
+
+    const project = file.getProject();
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(false);
+  });
+
+  test("returns false for empty source files array", () => {
+    const actual = detectSaltProviderNext([]);
+    expect(actual).toBe(false);
+  });
+
+  test("detects SaltProviderNext in multiple files", () => {
+    const project = new tsm.Project({ useInMemoryFileSystem: true });
+
+    project.createSourceFile(
+      "file1.tsx",
+      `import { Button } from "@salt-ds/core";
+
+  export const Component1 = () => <Button>Click</Button>;`
+    );
+
+    project.createSourceFile(
+      "file2.tsx",
+      `import { SaltProviderNext } from "@salt-ds/core";
+
+  export const Component2 = () => (
+    <SaltProviderNext>
+      <div>Content</div>
+    </SaltProviderNext>
+  );`
+    );
+
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(true);
+  });
+
+  test("returns false when SaltProviderNext is from different package", () => {
+    const file = createFileWithContent(
+      `import { SaltProviderNext } from "some-other-package";
+
+  export const App = () => {
+    return (
+      <SaltProviderNext>
+        <div>Hello</div>
+      </SaltProviderNext>
+    );
+  };`
+    );
+
+    const project = file.getProject();
+    const sourceFiles = project.getSourceFiles();
+    const actual = detectSaltProviderNext(sourceFiles);
+
+    expect(actual).toBe(false);
   });
 });

--- a/index.js
+++ b/index.js
@@ -88,6 +88,36 @@ const {
   cssModeGlob: cssGlob,
 } = parsedArgs;
 
+/**
+ * Detects if SaltProviderNext is imported in any of the source files
+ * @param {import('ts-morph').SourceFile[]} files - Array of source files to check
+ * @returns {boolean} True if SaltProviderNext is found, false otherwise
+ */
+function detectSaltProviderNext(files) {
+  for (const file of files) {
+    const importDeclarations = file.getImportDeclarations();
+    for (const importDecl of importDeclarations) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue();
+      if (
+        moduleSpecifier === "@salt-ds/core" ||
+        moduleSpecifier === "@salt-ds/lab"
+      ) {
+        const namedImports = importDecl.getNamedImports();
+        for (const namedImport of namedImports) {
+          if (namedImport.getName() === "SaltProviderNext") {
+            verboseOnlyLog(
+              "Detected SaltProviderNext in",
+              file.getFilePath()
+            );
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 const v100 = parse("1.0.0");
 const v110 = parse("1.1.0");
 const v120 = parse("1.2.0");
@@ -431,31 +461,7 @@ if (mode === undefined || mode === "css") {
       }
 
       const detectionFiles = detectionProject.getSourceFiles();
-
-      for (const file of detectionFiles) {
-        const importDeclarations = file.getImportDeclarations();
-        for (const importDecl of importDeclarations) {
-          const moduleSpecifier = importDecl.getModuleSpecifierValue();
-          if (
-            moduleSpecifier === "@salt-ds/core" ||
-            moduleSpecifier === "@salt-ds/lab"
-          ) {
-            const namedImports = importDecl.getNamedImports();
-            for (const namedImport of namedImports) {
-              if (namedImport.getName() === "SaltProviderNext") {
-                usesSaltProviderNext = true;
-                verboseOnlyLog(
-                  "Detected SaltProviderNext in",
-                  file.getFilePath()
-                );
-                break;
-              }
-            }
-          }
-          if (usesSaltProviderNext) break;
-        }
-        if (usesSaltProviderNext) break;
-      }
+      usesSaltProviderNext = detectSaltProviderNext(detectionFiles);
     } catch (error) {
       verboseOnlyDimLog(
         "Could not check for SaltProviderNext usage:",
@@ -464,38 +470,7 @@ if (mode === undefined || mode === "css") {
     }
   } else if (sourceFiles.length > 0) {
     // Reuse the source files from TS mode
-    for (const file of sourceFiles) {
-      const importDeclarations = file.getImportDeclarations();
-      for (const importDecl of importDeclarations) {
-        const moduleSpecifier = importDecl.getModuleSpecifierValue();
-        if (
-          moduleSpecifier === "@salt-ds/core" ||
-          moduleSpecifier === "@salt-ds/lab"
-        ) {
-          const namedImports = importDecl.getNamedImports();
-          for (const namedImport of namedImports) {
-            if (namedImport.getName() === "SaltProviderNext") {
-              usesSaltProviderNext = true;
-              verboseOnlyLog(
-                "Detected SaltProviderNext in",
-                file.getFilePath()
-              );
-              break;
-            }
-          }
-        }
-        if (usesSaltProviderNext) break;
-      }
-      if (usesSaltProviderNext) break;
-    }
-  }
-
-  if (usesSaltProviderNext) {
-    console.log(
-      chalk.dim(
-        "Detected SaltProviderNext usage - will include theme-next.css variables"
-      )
-    );
+    usesSaltProviderNext = detectSaltProviderNext(sourceFiles);
   }
 
   verboseOnlyDimLog(

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ const {
   to: toInput,
   skipUpgrade,
   themeCss,
+  themeNextCss,
   cssModeGlob: cssGlob,
 } = parsedArgs;
 
@@ -188,6 +189,10 @@ console.log(
 
 // <-------- TS Code ---------->
 
+// Keep track of project and source files for SaltProviderNext detection
+let project = null;
+let sourceFiles = [];
+
 if (mode === undefined || mode === "ts") {
   // Check, in case of monorepo which doesn't have tsconfig at the root
   const tsConfigExisted = existsSync(tsconfig);
@@ -195,7 +200,7 @@ if (mode === undefined || mode === "ts") {
   // Ignore tsconfig if `tsSourceGlob` option is provided
   const initialiseFromTsConfig = !tsSourceGlob && tsConfigExisted;
 
-  const project = new Project({
+  project = new Project({
     // Optionally specify compiler options, tsconfig.json, in-memory file system, and more here.
     // If you initialize with a tsconfig.json, then it will automatically populate the project
     // with the associated source files.
@@ -220,7 +225,7 @@ if (mode === undefined || mode === "ts") {
     project.addSourceFilesAtPaths(tsSourceGlob);
   }
 
-  const sourceFiles = project.getSourceFiles();
+  sourceFiles = project.getSourceFiles();
   console.log(chalk.dim("Found", sourceFiles.length, "source files"));
 
   for (const file of sourceFiles) {
@@ -408,6 +413,91 @@ if (mode === undefined || mode === "ts") {
 if (mode === undefined || mode === "css") {
   console.log(chalk.dim("Starting CSS variable migrations"));
 
+  // Detect if SaltProviderNext is being used in the codebase
+  let usesSaltProviderNext = false;
+
+  // If we didn't run TS mode, we need to create a project just for detection
+  if (mode === "css") {
+    try {
+      const tsConfigExisted = existsSync(tsconfig);
+      const initialiseFromTsConfig = !tsSourceGlob && tsConfigExisted;
+
+      const detectionProject = new Project({
+        tsConfigFilePath: initialiseFromTsConfig ? tsconfig : undefined,
+      });
+
+      if (!initialiseFromTsConfig && tsSourceGlob) {
+        detectionProject.addSourceFilesAtPaths(tsSourceGlob);
+      }
+
+      const detectionFiles = detectionProject.getSourceFiles();
+
+      for (const file of detectionFiles) {
+        const importDeclarations = file.getImportDeclarations();
+        for (const importDecl of importDeclarations) {
+          const moduleSpecifier = importDecl.getModuleSpecifierValue();
+          if (
+            moduleSpecifier === "@salt-ds/core" ||
+            moduleSpecifier === "@salt-ds/lab"
+          ) {
+            const namedImports = importDecl.getNamedImports();
+            for (const namedImport of namedImports) {
+              if (namedImport.getName() === "SaltProviderNext") {
+                usesSaltProviderNext = true;
+                verboseOnlyLog(
+                  "Detected SaltProviderNext in",
+                  file.getFilePath()
+                );
+                break;
+              }
+            }
+          }
+          if (usesSaltProviderNext) break;
+        }
+        if (usesSaltProviderNext) break;
+      }
+    } catch (error) {
+      verboseOnlyDimLog(
+        "Could not check for SaltProviderNext usage:",
+        error.message
+      );
+    }
+  } else if (sourceFiles.length > 0) {
+    // Reuse the source files from TS mode
+    for (const file of sourceFiles) {
+      const importDeclarations = file.getImportDeclarations();
+      for (const importDecl of importDeclarations) {
+        const moduleSpecifier = importDecl.getModuleSpecifierValue();
+        if (
+          moduleSpecifier === "@salt-ds/core" ||
+          moduleSpecifier === "@salt-ds/lab"
+        ) {
+          const namedImports = importDecl.getNamedImports();
+          for (const namedImport of namedImports) {
+            if (namedImport.getName() === "SaltProviderNext") {
+              usesSaltProviderNext = true;
+              verboseOnlyLog(
+                "Detected SaltProviderNext in",
+                file.getFilePath()
+              );
+              break;
+            }
+          }
+        }
+        if (usesSaltProviderNext) break;
+      }
+      if (usesSaltProviderNext) break;
+    }
+  }
+
+  if (usesSaltProviderNext) {
+    console.log(
+      chalk.dim(
+        "Detected SaltProviderNext usage - will include theme-next.css variables"
+      )
+    );
+  }
+
   verboseOnlyDimLog(
     "Reading Salt theme CSS variables from",
     relative(process.cwd(), themeCss)
@@ -419,6 +509,30 @@ if (mode === undefined || mode === "css") {
   const allSaltThemeCssVars = new Set(
     [...saltThemeCssContent.matchAll(/--salt[-\w]+\b/g)].map((x) => x[0])
   );
+
+  // If SaltProviderNext is detected and theme-next.css exists, also load its variables
+  if (usesSaltProviderNext && existsSync(themeNextCss)) {
+    verboseOnlyDimLog(
+      "Reading additional Salt theme CSS variables from",
+      relative(process.cwd(), themeNextCss)
+    );
+    const saltThemeNextCssContent = readFileSync(themeNextCss, {
+      encoding: "utf8",
+      flag: "r",
+    });
+    const themeNextVars = [
+      ...saltThemeNextCssContent.matchAll(/--salt[-\w]+\b/g),
+    ].map((x) => x[0]);
+
+    themeNextVars.forEach((cssVar) => allSaltThemeCssVars.add(cssVar));
+
+    verboseOnlyDimLog(
+      "Added",
+      themeNextVars.length,
+      "variables from theme-next.css"
+    );
+  }
+
   verboseOnlyDimLog(
     "Total valid Salt theme CSS var count:",
     allSaltThemeCssVars.size

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ import { css160RenameMap, react160 } from "./migration/core160.js";
 import { react180 } from "./migration/core180.js";
 import { css182RenameMap } from "./migration/core182.js";
 import {
+  detectSaltProviderNext,
   getCssRenameCheckRegex,
   migrateCssVar,
   warnUnknownSaltThemeVars,
@@ -87,36 +88,6 @@ const {
   themeNextCss,
   cssModeGlob: cssGlob,
 } = parsedArgs;
-
-/**
- * Detects if SaltProviderNext is imported in any of the source files
- * @param {import('ts-morph').SourceFile[]} files - Array of source files to check
- * @returns {boolean} True if SaltProviderNext is found, false otherwise
- */
-function detectSaltProviderNext(files) {
-  for (const file of files) {
-    const importDeclarations = file.getImportDeclarations();
-    for (const importDecl of importDeclarations) {
-      const moduleSpecifier = importDecl.getModuleSpecifierValue();
-      if (
-        moduleSpecifier === "@salt-ds/core" ||
-        moduleSpecifier === "@salt-ds/lab"
-      ) {
-        const namedImports = importDecl.getNamedImports();
-        for (const namedImport of namedImports) {
-          if (namedImport.getName() === "SaltProviderNext") {
-            verboseOnlyLog(
-              "Detected SaltProviderNext in",
-              file.getFilePath()
-            );
-            return true;
-          }
-        }
-      }
-    }
-  }
-  return false;
-}
 
 const v100 = parse("1.0.0");
 const v110 = parse("1.1.0");

--- a/migration/utils.js
+++ b/migration/utils.js
@@ -359,3 +359,33 @@ export function migrateCssVar(line, renameRegex, renameMap) {
     return to;
   });
 }
+
+/**
+ * Detects if SaltProviderNext is imported in any of the source files
+ * @param {import('ts-morph').SourceFile[]} files - Array of source files to check
+ * @returns {boolean} True if SaltProviderNext is found, false otherwise
+ */
+export function detectSaltProviderNext(files) {
+  for (const file of files) {
+    const importDeclarations = file.getImportDeclarations();
+    for (const importDecl of importDeclarations) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue();
+      if (
+        moduleSpecifier === "@salt-ds/core" ||
+        moduleSpecifier === "@salt-ds/lab"
+      ) {
+        const namedImports = importDecl.getNamedImports();
+        for (const namedImport of namedImports) {
+          if (namedImport.getName() === "SaltProviderNext") {
+            verboseOnlyLog(
+              "Detected SaltProviderNext in",
+              file.getFilePath()
+            );
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/utils/args.js
+++ b/utils/args.js
@@ -26,6 +26,12 @@ export const parsedArgs = await yargs
     description:
       "Custom path for `@salt-ds/theme/index.css` file used in CSS mode.",
   })
+  .option("themeNextCss", {
+    type: "string",
+    default: "node_modules/@salt-ds/theme/theme-next.css",
+    description:
+      "Custom path for `@salt-ds/theme/theme-next.css` file used in CSS mode when SaltProviderNext is detected.",
+  })
   .option("cssModeGlob", {
     type: "string",
     default: "*/**/*.@(css|ts|tsx)",


### PR DESCRIPTION
Implements detection of SaltProviderNext usage and includes CSS variables
from theme-next.css when validating, preventing false errors for variables
defined in the newer theme configuration.

- Add --themeNextCss CLI option to customize theme-next.css path
- Detect SaltProviderNext imports in source files
- Load and merge CSS variables from both index.css and theme-next.css
- Works in both combined mode and CSS-only mode

Fixes #25