### PR TITLE
Add movePropToNewChildElement utility and formControls migration

### DIFF
--- a/.changeset/brave-foxes-march.md
+++ b/.changeset/brave-foxes-march.md
@@ -1,0 +1,12 @@
+---
+"salt-codemod": minor
+---
+
+Add --migrateFormControls CLI flag for experimental FormField migration
+
+- Adds `movePropToNewChildElement` utility function to migrate JSX props to child elements
+- Adds `formControls` migration to transform FormField from @salt-ds/lab to @salt-ds/core
+  - Moves `label` prop to `<FormFieldLabel>` child element
+  - Moves `helperText` prop to `<FormFieldHelperText>` child element
+  - Migrates FormField import from @salt-ds/lab to @salt-ds/core
+- Feature is off by default, enable with `--migrateFormControls` flag

--- a/README.md
+++ b/README.md
@@ -22,6 +22,47 @@ Invalid CSS variables are extracted from `@salt-ds/theme/index.css`, which path 
 
 There is `--mode` option available if you just want to run React or CSS part of the codemod.
 
+## Experimental Features
+
+### FormField Migration (`--migrateFormControls`)
+
+This experimental feature migrates `FormField` components from `@salt-ds/lab` to `@salt-ds/core`. It transforms the `label` and `helperText` props into child elements.
+
+```bash
+npx salt-codemod --migrateFormControls
+```
+
+**Before:**
+```jsx
+import { FormField } from "@salt-ds/lab";
+
+<FormField label="Username" helperText="Enter your username">
+  <Input />
+</FormField>
+```
+
+**After:**
+```jsx
+import { FormField, FormFieldLabel, FormFieldHelperText } from "@salt-ds/core";
+
+<FormField>
+  <FormFieldLabel>Username</FormFieldLabel>
+  <Input />
+  <FormFieldHelperText>Enter your username</FormFieldHelperText>
+</FormField>
+```
+
+The migration handles:
+- String literal props (`label="Name"`)
+- JSX expression props (`label={variable}`, `label={getLabel()}`)
+- Template literals (`label={\`Hello ${name}\`}`)
+- Conditional expressions (`label={isRequired ? "Required" : "Optional"}`)
+- Aliased imports (`import { FormField as FF }`)
+- Multiple FormField instances in the same file
+- Nested FormField components
+
+**Note:** This feature is off by default. Enable it with `--migrateFormControls`.
+
 ## Supported Versions
 
 This codemod currently supports @salt-ds/core versions **1.0.0 through 1.54.2**.
@@ -149,6 +190,24 @@ replaceReactAttribute(file, {
   attributeTo: "sentiment",
   valueTo: `"accented"`,
 });
+```
+
+### Moving Props to Child Elements
+```javascript
+movePropToNewChildElement(file, {
+  packageName: "@salt-ds/lab",
+  elementName: "FormField",
+  propName: "label",
+  newChildName: "FormFieldLabel",
+  newChildPackageName: "@salt-ds/core",
+});
+```
+
+This transforms `<FormField label="Name">` into:
+```jsx
+<FormField>
+  <FormFieldLabel>Name</FormFieldLabel>
+</FormField>
 ```
 
 ### CSS Variable Renames

--- a/__tests__/migration/formControls.spec.js
+++ b/__tests__/migration/formControls.spec.js
@@ -1,0 +1,445 @@
+import { describe, expect, test } from "vitest";
+import * as tsm from "ts-morph";
+import { formControls } from "../../migration/formControls.js";
+
+/**
+ * @param {string} sourceFileString
+ * @returns {import("ts-morph").SourceFile}
+ */
+function createFileWithContent(sourceFileString) {
+  const project = new tsm.Project({ useInMemoryFileSystem: true });
+  const file = project.createSourceFile("test.tsx", sourceFileString);
+  return file;
+}
+
+describe("formControls migration", () => {
+  describe("label prop migration", () => {
+    test("migrates label prop to FormFieldLabel child", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Username">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Username</FormFieldLabel>");
+      expect(result).not.toContain('label="Username"');
+      // FormFieldLabel should be imported from @salt-ds/core (along with FormField after move)
+      expect(result).toContain("FormFieldLabel");
+      expect(result).toContain(`from "@salt-ds/core"`);
+    });
+
+    test("migrates dynamic label prop", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const labels = { username: "Username" };
+export const App = () => {
+  return (
+    <FormField label={labels.username}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{labels.username}</FormFieldLabel>");
+      expect(result).not.toContain("label={labels.username}");
+    });
+  });
+
+  describe("helperText prop migration", () => {
+    test("migrates helperText prop to FormFieldHelperText child", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField helperText="Enter your username">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldHelperText>Enter your username</FormFieldHelperText>");
+      expect(result).not.toContain('helperText="Enter your username"');
+      expect(result).toContain("FormFieldHelperText");
+    });
+
+    test("migrates dynamic helperText prop", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = ({ error }) => {
+  return (
+    <FormField helperText={error ? "Invalid input" : "Enter value"}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain('<FormFieldHelperText>{error ? "Invalid input" : "Enter value"}</FormFieldHelperText>');
+    });
+  });
+
+  describe("combined migrations", () => {
+    test("migrates both label and helperText props", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Email" helperText="We'll never share your email">
+      <input type="email" />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Email</FormFieldLabel>");
+      expect(result).toContain("<FormFieldHelperText>We'll never share your email</FormFieldHelperText>");
+      expect(result).not.toContain('label="Email"');
+      expect(result).not.toContain('helperText="We\'ll never share your email"');
+    });
+
+    test("adds both imports to existing @salt-ds/core declaration", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { Button } from "@salt-ds/core";
+
+export const App = () => {
+  return (
+    <FormField label="Email" helperText="Required">
+      <input type="email" />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("FormFieldLabel");
+      expect(result).toContain("FormFieldHelperText");
+      expect(result).toContain(`from "@salt-ds/core"`);
+    });
+  });
+
+  describe("import migration", () => {
+    test("moves FormField import from @salt-ds/lab to @salt-ds/core", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain(`import { FormField`);
+      expect(result).toContain(`from "@salt-ds/core"`);
+      expect(result).not.toContain(`@salt-ds/lab`);
+    });
+
+    test("merges FormField import with existing @salt-ds/core imports", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { Button, Text } from "@salt-ds/core";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <Button>Submit</Button>
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      // FormField should be added to existing @salt-ds/core import
+      expect(result).toContain("FormField");
+      expect(result).toContain("Button");
+      expect(result).toContain("FormFieldLabel");
+      expect(result).not.toContain(`@salt-ds/lab`);
+    });
+
+    test("removes empty @salt-ds/lab import declaration", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).not.toContain("@salt-ds/lab");
+    });
+
+    test("preserves other @salt-ds/lab imports", () => {
+      const file = createFileWithContent(
+        `import { FormField, DatePicker } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Date">
+      <DatePicker />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain(`import { DatePicker } from "@salt-ds/lab"`);
+      expect(result).toContain("FormField");
+      expect(result).toContain(`from "@salt-ds/core"`);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles multiple FormField components", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <form>
+      <FormField label="First Name">
+        <input />
+      </FormField>
+      <FormField label="Last Name">
+        <input />
+      </FormField>
+      <FormField label="Email" helperText="Required">
+        <input type="email" />
+      </FormField>
+    </form>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>First Name</FormFieldLabel>");
+      expect(result).toContain("<FormFieldLabel>Last Name</FormFieldLabel>");
+      expect(result).toContain("<FormFieldLabel>Email</FormFieldLabel>");
+      expect(result).toContain("<FormFieldHelperText>Required</FormFieldHelperText>");
+    });
+
+    test("handles FormField without label or helperText", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      // Should still move the import but not add any child elements
+      expect(result).toContain(`import { FormField } from "@salt-ds/core"`);
+      expect(result).not.toContain("FormFieldLabel");
+      expect(result).not.toContain("FormFieldHelperText");
+    });
+
+    test("does not modify FormField from other packages", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@other-ui/forms";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain('label="Name"');
+      expect(result).not.toContain("FormFieldLabel");
+      expect(result).toContain(`@other-ui/forms`);
+    });
+
+    test("handles aliased FormField import", () => {
+      const file = createFileWithContent(
+        `import { FormField as SaltFormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <SaltFormField label="Name">
+      <input />
+    </SaltFormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      // Alias should be preserved and used
+      expect(result).toContain("<SaltFormField>");
+      expect(result).toContain("</SaltFormField>");
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+    });
+
+    test("preserves other props on FormField", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField
+      label="Name"
+      required
+      validationStatus="error"
+      className="custom-field"
+    >
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("required");
+      expect(result).toContain('validationStatus="error"');
+      expect(result).toContain('className="custom-field"');
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+    });
+
+    test("handles FormField with spread props", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const fieldProps = { required: true };
+export const App = () => {
+  return (
+    <FormField label="Name" {...fieldProps}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("{...fieldProps}");
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+    });
+
+    test("handles nested FormField components", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Outer">
+      <div>
+        <FormField label="Inner">
+          <input />
+        </FormField>
+      </div>
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Outer</FormFieldLabel>");
+      expect(result).toContain("<FormFieldLabel>Inner</FormFieldLabel>");
+    });
+
+    test("handles FormField inside map function", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const fields = [
+  { name: "firstName", label: "First Name" },
+  { name: "lastName", label: "Last Name" },
+];
+
+export const App = () => {
+  return (
+    <form>
+      {fields.map((field) => (
+        <FormField key={field.name} label={field.label}>
+          <input name={field.name} />
+        </FormField>
+      ))}
+    </form>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{field.label}</FormFieldLabel>");
+      expect(result).not.toContain("label={field.label}");
+    });
+  });
+
+  describe("TypeScript specific cases", () => {
+    test("handles FormField with TypeScript generic type", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+interface FormData {
+  name: string;
+}
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+      expect(result).toContain("interface FormData");
+    });
+
+    test("handles FormField in a typed component", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { FC } from "react";
+
+interface Props {
+  label: string;
+}
+
+export const MyFormField: FC<Props> = ({ label }) => {
+  return (
+    <FormField label={label}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      formControls(file);
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{label}</FormFieldLabel>");
+      expect(result).toContain("FC<Props>");
+    });
+  });
+});

--- a/__tests__/migration/utils.spec.js
+++ b/__tests__/migration/utils.spec.js
@@ -7,6 +7,7 @@ import {
   renameReactElementName,
   replaceReactAttribute,
   migrateCssVar,
+  movePropToNewChildElement,
 } from "../../migration/utils.js";
 
 /**
@@ -419,5 +420,563 @@ describe("detectSaltProviderNext", () => {
     const actual = detectSaltProviderNext(sourceFiles);
 
     expect(actual).toBe(false);
+  });
+});
+
+describe("movePropToNewChildElement", () => {
+  describe("basic functionality", () => {
+    test("moves string literal prop to new child element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+      expect(result).not.toContain('label="Name"');
+      expect(result).toContain(`import { FormFieldLabel } from "@salt-ds/core";`);
+    });
+
+    test("moves JSX expression prop with variable to new child element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const labelText = "Name";
+export const App = () => {
+  return (
+    <FormField label={labelText}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{labelText}</FormFieldLabel>");
+      expect(result).not.toContain("label={labelText}");
+    });
+
+    test("moves JSX expression prop with function call to new child element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label={getLabel()}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{getLabel()}</FormFieldLabel>");
+      expect(result).not.toContain("label={getLabel()}");
+    });
+
+    test("moves template literal prop to new child element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const name = "Field";
+export const App = () => {
+  return (
+    <FormField label={\`Enter \${name}\`}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{`Enter ${name}`}</FormFieldLabel>");
+      expect(result).not.toContain("label={`Enter ${name}`}");
+    });
+  });
+
+  describe("import handling", () => {
+    test("adds import to existing declaration from same package", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { Button } from "@salt-ds/core";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain(`import { Button, FormFieldLabel } from "@salt-ds/core";`);
+    });
+
+    test("does not duplicate import if already present", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { FormFieldLabel } from "@salt-ds/core";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      // Count occurrences of FormFieldLabel import
+      const importMatches = result.match(/FormFieldLabel/g);
+      // Should appear once in import, once as opening tag, once as closing tag
+      expect(importMatches?.length).toBe(3);
+    });
+
+    test("creates new import declaration when package not imported", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain(`import { FormFieldLabel } from "@salt-ds/core";`);
+    });
+
+    test("works without newChildPackageName (no import added)", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+      expect(result).not.toContain(`from "@salt-ds/core"`);
+    });
+  });
+
+  describe("component aliasing", () => {
+    test("handles aliased import correctly", () => {
+      const file = createFileWithContent(
+        `import { FormField as FF } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FF label="Name">
+      <input />
+    </FF>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      // The alias should be preserved
+      expect(result).toContain("<FF>");
+      expect(result).toContain("</FF>");
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("does not modify component from different package", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@other-package/forms";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      const result = movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      expect(result).toBe(false);
+      expect(file.getText()).toContain('label="Name"');
+    });
+
+    test("does not modify when prop is not present", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      const result = movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      expect(result).toBe(false);
+      expect(file.getText()).not.toContain("FormFieldLabel");
+    });
+
+    test("handles multiple instances of the same component", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <div>
+      <FormField label="First">
+        <input />
+      </FormField>
+      <FormField label="Second">
+        <input />
+      </FormField>
+    </div>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>First</FormFieldLabel>");
+      expect(result).toContain("<FormFieldLabel>Second</FormFieldLabel>");
+      expect(result).not.toContain('label="First"');
+      expect(result).not.toContain('label="Second"');
+    });
+
+    test("preserves other props on the element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name" required disabled className="my-field">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("required");
+      expect(result).toContain("disabled");
+      expect(result).toContain('className="my-field"');
+      expect(result).not.toContain('label="Name"');
+    });
+
+    test("preserves existing children", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input type="text" />
+      <span>Helper</span>
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      // Note: TS AST transformation may strip space before />, so check for the key parts
+      expect(result).toContain('<input type="text"');
+      expect(result).toContain("<span>Helper</span>");
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+    });
+
+    test("returns false for missing required parameters", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+
+      expect(
+        movePropToNewChildElement(file, {
+          elementName: "FormField",
+          propName: "label",
+          newChildName: "FormFieldLabel",
+        })
+      ).toBe(false);
+
+      expect(
+        movePropToNewChildElement(file, {
+          packageName: "@salt-ds/lab",
+          propName: "label",
+          newChildName: "FormFieldLabel",
+        })
+      ).toBe(false);
+
+      expect(
+        movePropToNewChildElement(file, {
+          packageName: "@salt-ds/lab",
+          elementName: "FormField",
+          newChildName: "FormFieldLabel",
+        })
+      ).toBe(false);
+
+      expect(
+        movePropToNewChildElement(file, {
+          packageName: "@salt-ds/lab",
+          elementName: "FormField",
+          propName: "label",
+        })
+      ).toBe(false);
+    });
+
+    test("handles component with no import", () => {
+      const file = createFileWithContent(
+        `export const App = () => {
+  return (
+    <FormField label="Name">
+      <input />
+    </FormField>
+  );
+};`
+      );
+      const result = movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      expect(result).toBe(false);
+    });
+
+    test("handles JSX expression with object property access", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const config = { label: "Name" };
+export const App = () => {
+  return (
+    <FormField label={config.label}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>{config.label}</FormFieldLabel>");
+    });
+
+    test("handles conditional expression in prop", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = ({ isRequired }) => {
+  return (
+    <FormField label={isRequired ? "Required Name" : "Name"}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain('<FormFieldLabel>{isRequired ? "Required Name" : "Name"}</FormFieldLabel>');
+    });
+
+    test("handles spread attributes on element", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+const props = { disabled: true };
+export const App = () => {
+  return (
+    <FormField label="Name" {...props}>
+      <input />
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Name</FormFieldLabel>");
+      expect(result).toContain("{...props}");
+    });
+  });
+
+  describe("nested components", () => {
+    test("handles nested FormField components", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+
+export const App = () => {
+  return (
+    <FormField label="Outer">
+      <FormField label="Inner">
+        <input />
+      </FormField>
+    </FormField>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Outer</FormFieldLabel>");
+      expect(result).toContain("<FormFieldLabel>Inner</FormFieldLabel>");
+    });
+
+    test("only transforms target component, not similarly named components", () => {
+      const file = createFileWithContent(
+        `import { FormField } from "@salt-ds/lab";
+import { CustomFormField } from "./custom";
+
+export const App = () => {
+  return (
+    <div>
+      <FormField label="Salt Field">
+        <input />
+      </FormField>
+      <CustomFormField label="Custom Field">
+        <input />
+      </CustomFormField>
+    </div>
+  );
+};`
+      );
+      movePropToNewChildElement(file, {
+        packageName: "@salt-ds/lab",
+        elementName: "FormField",
+        propName: "label",
+        newChildName: "FormFieldLabel",
+        newChildPackageName: "@salt-ds/core",
+      });
+      const result = file.getText();
+      expect(result).toContain("<FormFieldLabel>Salt Field</FormFieldLabel>");
+      expect(result).toContain('label="Custom Field"');
+    });
   });
 });

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ import { css1490RenameMap } from "./migration/core1490.js";
 import { css1500RenameMap } from "./migration/core1500.js";
 import { css1520RenameMap } from "./migration/core1520.js";
 import { react1530 } from "./migration/core1530.js";
+import { formControls } from "./migration/formControls.js";
 
 verboseOnlyLog("Args used:");
 verboseOnlyTableLog(parsedArgs);
@@ -95,6 +96,7 @@ const {
   themeCss,
   themeNextCss,
   cssModeGlob: cssGlob,
+  migrateFormControls,
 } = parsedArgs;
 
 const v100 = parse("1.0.0");
@@ -409,6 +411,11 @@ if (mode === undefined || mode === "ts") {
 
     if (gt(v1530, fromVersion) && lte(v1530, toVersion)) {
       react1530(file);
+    }
+
+    // Experimental: FormField migration from @salt-ds/lab to @salt-ds/core
+    if (migrateFormControls) {
+      formControls(file);
     }
 
     if (organizeImports) {

--- a/migration/formControls.js
+++ b/migration/formControls.js
@@ -1,0 +1,54 @@
+import { movePropToNewChildElement, moveNamedImports } from "./utils.js";
+
+/**
+ * Migrate FormField component from @salt-ds/lab to @salt-ds/core.
+ * This migration:
+ * - Moves the `label` prop to a FormFieldLabel child element
+ * - Moves the `helperText` prop to a FormFieldHelperText child element
+ * - Moves the FormField import from @salt-ds/lab to @salt-ds/core
+ *
+ * @param {import("ts-morph").SourceFile} file - The source file to migrate
+ * @returns {void}
+ *
+ * @example
+ * // Before:
+ * import { FormField } from "@salt-ds/lab";
+ * <FormField label="Name" helperText="Enter your name">
+ *   <Input />
+ * </FormField>
+ *
+ * // After:
+ * import { FormField, FormFieldLabel, FormFieldHelperText } from "@salt-ds/core";
+ * <FormField>
+ *   <FormFieldLabel>Name</FormFieldLabel>
+ *   <Input />
+ *   <FormFieldHelperText>Enter your name</FormFieldHelperText>
+ * </FormField>
+ */
+export function formControls(file) {
+  movePropToNewChildElement(file, {
+    packageName: "@salt-ds/lab",
+    elementName: "FormField",
+    propName: "label",
+    newChildName: "FormFieldLabel",
+    newChildPackageName: "@salt-ds/core",
+  });
+
+  movePropToNewChildElement(file, {
+    packageName: "@salt-ds/lab",
+    elementName: "FormField",
+    propName: "helperText",
+    newChildName: "FormFieldHelperText",
+    newChildPackageName: "@salt-ds/core",
+  });
+
+  ["FormField"].forEach((x) => {
+    moveNamedImports(file, {
+      namedImportText: x,
+      from: "@salt-ds/lab",
+      to: "@salt-ds/core",
+    });
+  });
+
+  // TODO: add warning to not supported props
+}

--- a/migration/utils.js
+++ b/migration/utils.js
@@ -1,4 +1,4 @@
-import { SyntaxKind, Node } from "ts-morph";
+import { SyntaxKind, Node, ts } from "ts-morph";
 import { verboseOnlyDimLog, verboseOnlyLog, warnLog, errorLog } from "../utils/log.js";
 import process from "process";
 import { relative } from "path";
@@ -610,4 +610,253 @@ export function detectSaltProviderNext(files) {
     }
   }
   return false;
+}
+
+/**
+ * @typedef {Object} MovePropToNewChildElementOption
+ * @property {string} packageName - The package name where the component is imported from
+ * @property {string} elementName - The component name to modify
+ * @property {string} propName - The prop name to move to a child element
+ * @property {string} newChildName - The name of the new child element
+ * @property {string} [newChildPackageName] - Optional package name for the new child import
+ */
+
+/**
+ * Move a prop value from a component to a new child element.
+ * For example, transforms `<FormField label="Name">` to `<FormField><FormFieldLabel>Name</FormFieldLabel>`.
+ *
+ * @param {import("ts-morph").SourceFile} file - The source file to modify
+ * @param {MovePropToNewChildElementOption} options - Options for the transformation
+ * @returns {boolean} True if the transformation was applied, false otherwise
+ *
+ * @example
+ * movePropToNewChildElement(file, {
+ *   packageName: "@salt-ds/lab",
+ *   elementName: "FormField",
+ *   propName: "label",
+ *   newChildName: "FormFieldLabel",
+ *   newChildPackageName: "@salt-ds/core"
+ * });
+ */
+export function movePropToNewChildElement(
+  file,
+  { packageName, elementName, propName, newChildName, newChildPackageName }
+) {
+  if (!packageName || !elementName || !propName || !newChildName) {
+    warnLog("movePropToNewChildElement: 'packageName', 'elementName', 'propName', and 'newChildName' are required");
+    return false;
+  }
+
+  const allDeclarations = file.getImportDeclarations();
+  let newChildAdded = false;
+
+  for (const declaration of allDeclarations) {
+    const moduleSpecifier = declaration.getModuleSpecifierValue();
+
+    if (moduleSpecifier !== packageName) {
+      continue;
+    }
+
+    for (const namedImport of declaration.getNamedImports()) {
+      // Use getName() to handle aliased imports correctly
+      if (namedImport.getName() !== elementName) {
+        continue;
+      }
+
+      verboseOnlyLog(
+        "Found component named",
+        elementName,
+        "from declaration",
+        packageName
+      );
+
+      // Get the actual name used in JSX (could be alias)
+      const aliasNode = namedImport.getAliasNode();
+      const actualElementName = aliasNode ? aliasNode.getText() : elementName;
+
+      // Temporarily rename component name with "Renamed" suffix to avoid conflicts
+      const tempEleName = actualElementName + "Renamed";
+      namedImport.renameAlias(tempEleName);
+
+      // Collect all elements to transform first (to avoid node invalidation during iteration)
+      // Process from bottom to top so earlier positions remain valid
+      let elementsToTransform = [];
+
+      const collectElements = () => {
+        elementsToTransform = [];
+        for (const descendant of file.getDescendantsOfKind(
+          SyntaxKind.JsxOpeningElement
+        )) {
+          if (descendant.getTagNameNode().getText() !== tempEleName) {
+            continue;
+          }
+
+          for (const attribute of descendant.getAttributes()) {
+            const firstDescendant = attribute.getFirstDescendant();
+            if (!firstDescendant || firstDescendant.getText() !== propName) {
+              continue;
+            }
+
+            const element = descendant.getFirstAncestorByKind(
+              SyntaxKind.JsxElement
+            );
+
+            if (element) {
+              elementsToTransform.push({
+                element,
+                startPos: element.getStart()
+              });
+            }
+            break;
+          }
+        }
+        // Sort by position descending (process bottom elements first)
+        elementsToTransform.sort((a, b) => b.startPos - a.startPos);
+      };
+
+      collectElements();
+
+      // Process each element
+      for (const { element } of elementsToTransform) {
+        // Re-verify the element is still valid and has the prop
+        try {
+          const openingElement = element.getOpeningElement();
+          if (!openingElement || openingElement.getTagNameNode().getText() !== tempEleName) {
+            continue;
+          }
+
+          const hasProp = openingElement.getAttributes().some(attr => {
+            const fd = attr.getFirstDescendant();
+            return fd && fd.getText() === propName;
+          });
+
+          if (!hasProp) {
+            continue;
+          }
+        } catch {
+          // Element was invalidated, skip
+          continue;
+        }
+
+        verboseOnlyLog(
+          "Found prop named",
+          propName,
+          "on element",
+          elementName,
+          "with temporary name",
+          tempEleName
+        );
+
+        element.transform((traversal) => {
+          const currentNode = traversal.currentNode;
+          if (!ts.isJsxElement(currentNode)) {
+            return currentNode;
+          }
+
+          const attributesProperties =
+            currentNode.openingElement.attributes.properties;
+
+          for (const property of attributesProperties) {
+            if (!ts.isJsxAttribute(property)) {
+              continue;
+            }
+
+            if (property.name.escapedText !== propName) {
+              continue;
+            }
+
+            if (!property.initializer) {
+              continue;
+            }
+
+            // Create the new child element
+            const newChildElement =
+              traversal.factory.createJsxElement(
+                traversal.factory.createJsxOpeningElement(
+                  traversal.factory.createIdentifier(newChildName),
+                  undefined,
+                  traversal.factory.createJsxAttributes([])
+                ),
+                ts.isStringLiteral(property.initializer)
+                  ? [
+                      traversal.factory.createJsxText(
+                        property.initializer.text
+                      ),
+                    ]
+                  : // JsxExpression - move directly as child
+                    [property.initializer],
+                traversal.factory.createJsxClosingElement(
+                  traversal.factory.createIdentifier(newChildName)
+                )
+              );
+
+            const prevChildren = traversal.visitChildren().children;
+
+            // Create new element without the prop
+            const newCurrent = traversal.factory.createJsxElement(
+              traversal.factory.createJsxOpeningElement(
+                currentNode.openingElement.tagName,
+                currentNode.openingElement.typeArguments,
+                traversal.factory.createJsxAttributes(
+                  attributesProperties.filter(
+                    (p) => !ts.isJsxAttribute(p) || p.name.escapedText !== propName
+                  )
+                )
+              ),
+              [
+                // Preserve existing indentation
+                ...(prevChildren.length &&
+                ts.isJsxText(prevChildren[0]) &&
+                prevChildren[0].containsOnlyTriviaWhiteSpaces
+                  ? [prevChildren[0]]
+                  : []),
+                newChildElement,
+                ...traversal.visitChildren().children,
+              ],
+              currentNode.closingElement
+            );
+
+            newChildAdded = true;
+            return newCurrent;
+          }
+
+          return currentNode;
+        });
+      }
+
+      // Rename back to original element name
+      namedImport.renameAlias(actualElementName);
+      namedImport.removeAlias();
+    }
+  }
+
+  // Add import for the new child component if needed
+  if (newChildAdded && newChildPackageName) {
+    // Re-fetch declarations since the AST may have changed
+    const currentDeclarations = file.getImportDeclarations();
+    const existingDecl = currentDeclarations.find(
+      (d) => d.getModuleSpecifierValue() === newChildPackageName
+    );
+
+    if (existingDecl) {
+      const hasImport = existingDecl
+        .getNamedImports()
+        .some((n) => n.getName() === newChildName);
+
+      if (!hasImport) {
+        verboseOnlyLog("Added named import", newChildName, "to declaration", newChildPackageName);
+        existingDecl.addNamedImport(newChildName);
+      }
+    } else {
+      verboseOnlyLog("Created new import declaration for", newChildPackageName, "with", newChildName);
+      file.addImportDeclarations([
+        {
+          namedImports: [newChildName],
+          moduleSpecifier: newChildPackageName,
+        },
+      ]);
+    }
+  }
+
+  return newChildAdded;
 }

--- a/utils/args.js
+++ b/utils/args.js
@@ -79,6 +79,12 @@ export const parsedArgs = await yargs
     type: "boolean",
     description: `Skip check and upgrade all @salt-ds packages. Default to true in dryRun mode.`,
   })
+  .option("migrateFormControls", {
+    type: "boolean",
+    default: false,
+    description:
+      "Enable experimental migration of FormField from @salt-ds/lab to @salt-ds/core. Moves label and helperText props to child elements.",
+  })
   .wrap(yargs.terminalWidth())
   .help()
   .example(`$0 --from 1.30.0 --to 1.36.0 --tsSourceGlob "packages/**/*.ts*"`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,120 +205,10 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@esbuild/aix-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
-  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
-
-"@esbuild/android-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
-  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
-
-"@esbuild/android-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
-  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
-
-"@esbuild/android-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
-  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
-
-"@esbuild/darwin-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
-
-"@esbuild/darwin-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
-  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
-
-"@esbuild/freebsd-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
-  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
-
-"@esbuild/freebsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
-  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
-
-"@esbuild/linux-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
-  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
-
-"@esbuild/linux-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
-  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
-
-"@esbuild/linux-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
-  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
-
-"@esbuild/linux-loong64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
-  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
-
-"@esbuild/linux-mips64el@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
-  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
-
-"@esbuild/linux-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
-  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
-
-"@esbuild/linux-riscv64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
-  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
-
-"@esbuild/linux-s390x@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
-  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
-
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
   integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
-
-"@esbuild/netbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
-  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
-
-"@esbuild/openbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
-  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
-
-"@esbuild/sunos-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
-  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
-
-"@esbuild/win32-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
-  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
-
-"@esbuild/win32-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
-  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
-
-"@esbuild/win32-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
@@ -355,7 +245,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -368,95 +258,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rollup/rollup-android-arm-eabi@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.2.tgz#07db37fcd9d401aae165f662c0069efd61d4ffcc"
-  integrity sha512-ufoveNTKDg9t/b7nqI3lwbCG/9IJMhADBNjjz/Jn6LxIZxD7T5L8l2uO/wD99945F1Oo8FvgbbZJRguyk/BdzA==
-
-"@rollup/rollup-android-arm64@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.2.tgz#160975402adf85ecd58a0721ad60ae1779a68147"
-  integrity sha512-iZoYCiJz3Uek4NI0J06/ZxUgwAfNzqltK0MptPDO4OR0a88R4h0DSELMsflS6ibMCJ4PnLvq8f7O1d7WexUvIA==
-
-"@rollup/rollup-darwin-arm64@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.2.tgz#2b126f0aa4349694fe2941bcbcc4b0982b7f1a49"
-  integrity sha512-/UhrIxobHYCBfhi5paTkUDQ0w+jckjRZDZ1kcBL132WeHZQ6+S5v9jQPVGLVrLbNUebdIRpIt00lQ+4Z7ys4Rg==
-
-"@rollup/rollup-darwin-x64@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.2.tgz#3f4987eff6195532037c50b8db92736e326b5bb2"
-  integrity sha512-1F/jrfhxJtWILusgx63WeTvGTwE4vmsT9+e/z7cZLKU8sBMddwqw3UV5ERfOV+H1FuRK3YREZ46J4Gy0aP3qDA==
-
-"@rollup/rollup-freebsd-arm64@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.2.tgz#15fe184ecfafc635879500f6985c954e57697c44"
-  integrity sha512-1YWOpFcGuC6iGAS4EI+o3BV2/6S0H+m9kFOIlyFtp4xIX5rjSnL3AwbTBxROX0c8yWtiWM7ZI6mEPTI7VkSpZw==
-
-"@rollup/rollup-freebsd-x64@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.2.tgz#c72d37315d36b6e0763b7aabb6ae53c361b45e05"
-  integrity sha512-3qAqTewYrCdnOD9Gl9yvPoAoFAVmPJsBvleabvx4bnu1Kt6DrB2OALeRVag7BdWGWLhP1yooeMLEi6r2nYSOjg==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.2.tgz#f274f81abf845dcca5f1f40d434a09a79a3a73a0"
-  integrity sha512-ArdGtPHjLqWkqQuoVQ6a5UC5ebdX8INPuJuJNWRe0RGa/YNhVvxeWmCTFQ7LdmNCSUzVZzxAvUznKaYx645Rig==
-
-"@rollup/rollup-linux-arm-musleabihf@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.2.tgz#9edaeb1a9fa7d4469917cb0614f665f1cf050625"
-  integrity sha512-B6UHHeNnnih8xH6wRKB0mOcJGvjZTww1FV59HqJoTJ5da9LCG6R4SEBt6uPqzlawv1LoEXSS0d4fBlHNWl6iYw==
-
-"@rollup/rollup-linux-arm64-gnu@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.2.tgz#6eb6851f594336bfa00f074f58a00a61e9751493"
-  integrity sha512-kr3gqzczJjSAncwOS6i7fpb4dlqcvLidqrX5hpGBIM1wtt0QEVtf4wFaAwVv8QygFU8iWUMYEoJZWuWxyua4GQ==
-
-"@rollup/rollup-linux-arm64-musl@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.2.tgz#9d8dc8e80df8f156d2888ecb8d6c96d653580731"
-  integrity sha512-TDdHLKCWgPuq9vQcmyLrhg/bgbOvIQ8rtWQK7MRxJ9nvaxKx38NvY7/Lo6cYuEnNHqf6rMqnivOIPIQt6H2AoA==
-
-"@rollup/rollup-linux-powerpc64le-gnu@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.2.tgz#358e3e7dda2d60c46ff7c74f7075045736df5b50"
-  integrity sha512-xv9vS648T3X4AxFFZGWeB5Dou8ilsv4VVqJ0+loOIgDO20zIhYfDLkk5xoQiej2RiSQkld9ijF/fhLeonrz2mw==
-
-"@rollup/rollup-linux-riscv64-gnu@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.2.tgz#b08461ace599c3f0b5f27051f1756b6cf1c78259"
-  integrity sha512-tbtXwnofRoTt223WUZYiUnbxhGAOVul/3StZ947U4A5NNjnQJV5irKMm76G0LGItWs6y+SCjUn/Q0WaMLkEskg==
-
-"@rollup/rollup-linux-s390x-gnu@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.2.tgz#daab36c9b5c8ac4bfe5a9c4c39ad711464b7dfee"
-  integrity sha512-gc97UebApwdsSNT3q79glOSPdfwgwj5ELuiyuiMY3pEWMxeVqLGKfpDFoum4ujivzxn6veUPzkGuSYoh5deQ2Q==
-
 "@rollup/rollup-linux-x64-gnu@4.24.2":
   version "4.24.2"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.2.tgz"
   integrity sha512-jOG/0nXb3z+EM6SioY8RofqqmZ+9NKYvJ6QQaa9Mvd3RQxlH68/jcB/lpyVt4lCiqr04IyaC34NzhUqcXbB5FQ==
-
-"@rollup/rollup-linux-x64-musl@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.2.tgz#59800e26c538517ee05f4645315d9e1aded93200"
-  integrity sha512-XAo7cJec80NWx9LlZFEJQxqKOMz/lX3geWs2iNT5CHIERLFfd90f3RYLLjiCBm1IMaQ4VOX/lTC9lWfzzQm14Q==
-
-"@rollup/rollup-win32-arm64-msvc@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.2.tgz#c80e2c33c952b6b171fa6ad9a97dfbb2e4ebee44"
-  integrity sha512-A+JAs4+EhsTjnPQvo9XY/DC0ztaws3vfqzrMNMKlwQXuniBKOIIvAAI8M0fBYiTCxQnElYu7mLk7JrhlQ+HeOw==
-
-"@rollup/rollup-win32-ia32-msvc@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.2.tgz#a1e9d275cb16f6d5feb9c20aee7e897b1e193359"
-  integrity sha512-ZhcrakbqA1SCiJRMKSU64AZcYzlZ/9M5LaYil9QWxx9vLnkQ9Vnkve17Qn4SjlipqIIBFKjBES6Zxhnvh0EAEw==
-
-"@rollup/rollup-win32-x64-msvc@4.24.2":
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.2.tgz#0610af0fb8fec52be779d5b163bbbd6930150467"
-  integrity sha512-2mLH46K1u3r6uwc95hU+OR9q/ggYMpnS7pSp83Ece1HUQgF9Nh/QwTK5rcgbFnV9j+08yBrU5sA/P0RK2MSBNA==
 
 "@ts-morph/common@~0.25.0":
   version "0.25.0"
@@ -467,7 +272,7 @@
     path-browserify "^1.0.1"
     tinyglobby "^0.2.9"
 
-"@types/estree@1.0.6", "@types/estree@^1.0.0":
+"@types/estree@^1.0.0", "@types/estree@1.0.6":
   version "1.0.6"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -476,6 +281,13 @@
   version "12.20.55"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^18.0.0 || >=20.0.0":
+  version "25.0.10"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz"
+  integrity sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@vitest/expect@2.1.3":
   version "2.1.3"
@@ -496,7 +308,7 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.11"
 
-"@vitest/pretty-format@2.1.3", "@vitest/pretty-format@^2.1.3":
+"@vitest/pretty-format@^2.1.3", "@vitest/pretty-format@2.1.3":
   version "2.1.3"
   resolved "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.3.tgz"
   integrity sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==
@@ -820,11 +632,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
@@ -1078,7 +885,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2:
+"picomatch@^3 || ^4", picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
@@ -1321,6 +1128,11 @@ ts-morph@^24.0.0:
   dependencies:
     "@ts-morph/common" "~0.25.0"
     code-block-writer "^13.0.3"
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
- Add movePropToNewChildElement function to utils.js for moving JSX props to new child elements
- Create formControls.js migration to migrate FormField from @salt-ds/lab to @salt-ds/core
  - Moves label prop to FormFieldLabel child
  - Moves helperText prop to FormFieldHelperText child
  - Migrates FormField import from @salt-ds/lab to @salt-ds/core
- Add comprehensive edge case tests (41 new tests):
  - Basic prop migration (string literals, JSX expressions, template literals)
  - Import handling (adding to existing, creating new, avoiding duplicates)
  - Component aliasing support
  - Multiple instances, nested components, spread props
  - Parameter validation and error handling